### PR TITLE
Fix shl_vx parameter name

### DIFF
--- a/chip8_hw.py
+++ b/chip8_hw.py
@@ -307,7 +307,7 @@ class ChipEightCpu(object):
             self.V[self.v_x] = self.V[self.v_y] - self.V[self.v_x]
         self.pc += 2
 
-    def shl_vx(self, opcoode):
+    def shl_vx(self, opcode):
         '''
         8xyE - SHL Vx {, Vy}
         '''


### PR DESCRIPTION
## Summary
- rename the parameter of `ChipEightCpu.shl_vx` from `opcoode` to `opcode`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c733cfc0832cbc714659084c2f68