### PR TITLE
Fix sprite wrapping on screen edges

### DIFF
--- a/chip8_hw.py
+++ b/chip8_hw.py
@@ -428,9 +428,9 @@ class ChipEightCpu(object):
             sprite_data.append(self.memory[self.I + x])
         for sprite_row in range(len(sprite_data)):
             for pixel_offset in range(8):
-                if (drw_y + sprite_row) >= 32 or (drw_x + pixel_offset) >= 64:
-                    continue
-                location = drw_x + pixel_offset + ((drw_y + sprite_row) * 64)
+                new_x = (drw_x + pixel_offset) % 64
+                new_y = (drw_y + sprite_row) % 32
+                location = new_x + (new_y * 64)
                 drw_mask = 1 << (7 - pixel_offset)
                 curr_pixel = (sprite_data[sprite_row] & drw_mask) >> (7 - pixel_offset)
                 if curr_pixel:

--- a/chip8_tests.py
+++ b/chip8_tests.py
@@ -461,6 +461,50 @@ def test_tk_to_sdl_pipeline_for_all_keys():
         assert cpu.key[expected] == 0
 
 
+def test_drw_wraps_horizontally():
+    cpu = chip8_hw.ChipEightCpu()
+    cpu.I = 0x300
+    cpu.memory[0x300] = 0b11000000
+    cpu.v_x = 1
+    cpu.v_y = 2
+    cpu.V[1] = 63
+    cpu.V[2] = 0
+    cpu.drw_vx_vy(0xD121)
+    assert cpu.gfx[63] == 1
+    assert cpu.gfx[0] == 1
+    assert cpu.V[0xF] == 0
+
+
+def test_drw_wraps_vertically():
+    cpu = chip8_hw.ChipEightCpu()
+    cpu.I = 0x300
+    cpu.memory[0x300] = 0b10000000
+    cpu.memory[0x301] = 0b10000000
+    cpu.v_x = 1
+    cpu.v_y = 2
+    cpu.V[1] = 0
+    cpu.V[2] = 31
+    cpu.drw_vx_vy(0xD122)
+    assert cpu.gfx[31 * 64] == 1
+    assert cpu.gfx[0] == 1
+    assert cpu.V[0xF] == 0
+
+
+def test_drw_collision_when_wrapping():
+    cpu = chip8_hw.ChipEightCpu()
+    cpu.gfx[0] = 1
+    cpu.I = 0x300
+    cpu.memory[0x300] = 0b11000000
+    cpu.v_x = 1
+    cpu.v_y = 2
+    cpu.V[1] = 63
+    cpu.V[2] = 0
+    cpu.drw_vx_vy(0xD121)
+    assert cpu.V[0xF] == 1
+    assert cpu.gfx[0] == 0
+    assert cpu.gfx[63] == 1
+
+
 
 
 # def test_0x00E0():


### PR DESCRIPTION
## Summary
- support screen wrapping in `drw_vx_vy`
- add regression tests for drawing across screen boundaries

## Testing
- `pytest chip8_tests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841404385a0832cb9c610237b4d8ec9