### PR TITLE
Add audio output for CHIP-8 timer

### DIFF
--- a/chip8_hw.py
+++ b/chip8_hw.py
@@ -33,6 +33,9 @@ class ChipEightCpu(object):
         #zero
         self.delay_timer = 0
         self.sound_timer = 0
+
+        # Track how many times the sound timer reached 1
+        self.beep_count = 0
         
         #The stack has 16 levels
         #I am unsure if I need stack pointer?
@@ -128,6 +131,7 @@ class ChipEightCpu(object):
         self.sound_timer = 0
         self.stack = []
         self.key = [0] * 16
+        self.beep_count = 0
 
         self._load_fontset()
 
@@ -189,8 +193,7 @@ class ChipEightCpu(object):
             self.delay_timer -= 1
         if self.sound_timer > 0:
             if self.sound_timer == 1:
-                # TODO: have sound and graphics
-                print("BEEP!\n")
+                self.beep_count += 1
             self.sound_timer -= 1
 
         if self.debug and self.debug_callback:

--- a/chip8emu.py
+++ b/chip8emu.py
@@ -262,8 +262,8 @@ def main():
         sdl2.AUDIO_S16SYS,
         1,
         frame_samples,
-        None,
-        None,
+        sdl2.SDL_AudioCallback(0),
+        ctypes.c_void_p(0),
     )
 
     audio_device = sdl2.SDL_OpenAudioDevice(None, 0, desired, None, 0)

--- a/chip8emu.py
+++ b/chip8emu.py
@@ -256,13 +256,15 @@ def main():
     )
     beep_bytes = beep_samples.tobytes()
 
-    desired = sdl2.SDL_AudioSpec()
-    desired.freq = sample_rate
-    desired.format = sdl2.AUDIO_S16SYS
-    desired.channels = 1
-    desired.samples = frame_samples
-    desired.callback = None
-    desired.userdata = None
+    # SDL_AudioSpec requires defaults provided via constructor
+    desired = sdl2.SDL_AudioSpec(
+        sample_rate,
+        sdl2.AUDIO_S16SYS,
+        1,
+        frame_samples,
+        None,
+        None,
+    )
 
     audio_device = sdl2.SDL_OpenAudioDevice(None, 0, desired, None, 0)
     sound_playing = False

--- a/chip8emu.py
+++ b/chip8emu.py
@@ -111,6 +111,10 @@ def create_menu(root, chip8_ref):
     labels["ST"].grid(row=row, column=0, columnspan=2, sticky="w")
     row += 1
 
+    labels["BEEPS"] = tk.Label(debug_win, text="BEEPS: 0")
+    labels["BEEPS"].grid(row=row, column=0, columnspan=2, sticky="w")
+    row += 1
+
     labels["CPS"] = tk.Label(debug_win, text="CPS: 0")
     labels["CPS"].grid(row=row, column=0, columnspan=2, sticky="w")
     row += 1
@@ -150,6 +154,7 @@ def create_menu(root, chip8_ref):
             labels["I"].config(text=f"I: {cpu.I:03X}")
             labels["DT"].config(text=f"DT: {cpu.delay_timer:02X}")
             labels["ST"].config(text=f"ST: {cpu.sound_timer:02X}")
+            labels["BEEPS"].config(text=f"BEEPS: {cpu.beep_count}")
             for i in range(16):
                 labels[f"V{i}"].config(text=f"{cpu.V[i]:02X}")
 


### PR DESCRIPTION
## Summary
- add SDL2 audio initialization and beep generator
- play/stop beeps when the CHIP-8 sound timer is active

## Testing
- `python -m py_compile chip8emu.py chip8_hw.py chip8_tests.py`
- `pytest -q chip8_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_684142a31b48832cb77117f6889fe99e